### PR TITLE
Feat default error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ module.exports = {
   // *** Usage: refer to unit test documents for specific rules ***
   rules: {
     // It is forbidden to use parameters in the @Body
-    'authing-nestjs/forbid_body_parameters': 'warn', // or 'error'
+    'authing-nestjs/forbid_body_parameters': 'warn', // default 'error'
 
     // It is forbidden to read body from Req
     'authing-nestjs/forbid_read_body_from_req': 'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9120,5 +9120,5 @@
       "dev": true
     }
   },
-  "version": "1.0.6"
+  "version": "1.0.7"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-authing-nestjs",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MIT",
   "description": "ESLint rules for nestjs framework",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,10 @@ export const rules = {
 export const configs = {
   recommended: {
     rules: {
-      'authing-nestjs/forbid_body_parameters': 1,
-      'authing-nestjs/forbid_read_body_from_req': 1,
-      'authing-nestjs/use_class_as_type_in_method_of_controller': 1,
-      'authing-nestjs/use_class_validator_to_dto': 1
+      'authing-nestjs/forbid_body_parameters': 2,
+      'authing-nestjs/forbid_read_body_from_req': 2,
+      'authing-nestjs/use_class_as_type_in_method_of_controller': 2,
+      'authing-nestjs/use_class_validator_to_dto': 2
     }
   }
 }


### PR DESCRIPTION
`error` is used instead of `warning` by default